### PR TITLE
feat(docker): add Docker environment for Claude agents, rename vault to Agents

### DIFF
--- a/claude/git_ssh.sh
+++ b/claude/git_ssh.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 eval "$(TMPDIR=/tmp/claude-1000 ssh-agent -s)" >/dev/null 2>&1
 trap 'ssh-agent -k >/dev/null 2>&1' EXIT
-if ! TMPDIR=/tmp/claude-1000 op item get "Claude SSH Key" --vault Claude --field "private key" --reveal 2>/dev/null | tr -d '"' | tail -n +2 | ssh-add - 2>/dev/null; then
+if ! TMPDIR=/tmp/claude-1000 op item get "Claude SSH Key" --vault Agents --field "private key" --reveal 2>/dev/null | tr -d '"' | tail -n +2 | ssh-add - 2>/dev/null; then
   echo "Failed to load SSH key from 1Password" >&2
   exit 1
 fi

--- a/claude/rc.sh
+++ b/claude/rc.sh
@@ -2,6 +2,6 @@ claude() {
   CLAUDE_TTY=$(tty 2>/dev/null) \
   GIT_CONFIG_GLOBAL=~/.config/git/claude \
   GIT_SSH_COMMAND="$HOME/.claude/git_ssh.sh" \
-  OP_SERVICE_ACCOUNT_TOKEN="${OP_SERVICE_ACCOUNT_TOKEN:-$(op item get "Service Account Auth Token: Claude" --vault Private --field credential --reveal)}" \
+  OP_SERVICE_ACCOUNT_TOKEN="${OP_SERVICE_ACCOUNT_TOKEN:-$(op item get "Service Account Auth Token: Agents" --vault Private --field credential --reveal)}" \
   command claude "$@"
 }

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,5 @@
+Dockerfile.proxy
+tinyproxy.conf
+tinyproxy-filter
+link.sh
+agent-run

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,71 @@
+FROM node:22-slim
+
+# Install essentials and external repo keys
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  ca-certificates \
+  curl \
+  git \
+  jq \
+  zsh \
+  less \
+  procps \
+  gnupg2 \
+  xz-utils \
+  && \
+  # GitHub CLI
+  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    > /etc/apt/sources.list.d/github-cli.list && \
+  # 1Password CLI
+  curl -sS https://downloads.1password.com/linux/keys/1password.asc \
+    | gpg --dearmor -o /usr/share/keyrings/1password-archive-keyring.gpg && \
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/$(dpkg --print-architecture) stable main" \
+    > /etc/apt/sources.list.d/1password-cli.list && \
+  apt-get update && apt-get install -y --no-install-recommends gh 1password-cli && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install helix editor
+ARG HELIX_VERSION=25.01.1
+RUN ARCH=$(dpkg --print-architecture) && \
+  case "$ARCH" in amd64) HELIX_ARCH=x86_64;; arm64) HELIX_ARCH=aarch64;; esac && \
+  curl -L "https://github.com/helix-editor/helix/releases/download/${HELIX_VERSION}/helix-${HELIX_VERSION}-${HELIX_ARCH}-linux.tar.xz" \
+    | tar xJ -C /opt && \
+  ln -s /opt/helix-${HELIX_VERSION}-${HELIX_ARCH}-linux/hx /usr/local/bin/hx
+
+# Ensure node user has access to global npm dir
+RUN mkdir -p /usr/local/share/npm-global && \
+  chown -R node:node /usr/local/share
+
+# Create workspace directory
+RUN mkdir -p /workspace && chown -R node:node /workspace
+
+WORKDIR /workspace
+
+USER node
+
+ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
+ENV PATH=/home/node/.local/bin:$PATH:/usr/local/share/npm-global/bin
+ENV SHELL=/bin/zsh
+ENV EDITOR=hx
+ENV VISUAL=hx
+ENV DEVCONTAINER=true
+
+# Install AI coding agents from npm (reproducible, no curl|bash)
+ARG CLAUDE_CODE_VERSION=latest
+ARG CODEX_VERSION=latest
+RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+ && npm install -g "@openai/codex@${CODEX_VERSION}"
+
+# Pre-seed Claude Code config to skip onboarding prompts
+RUN echo '{"hasCompletedOnboarding":true,"numStartups":1,"projects":{"/workspace":{"hasTrustDialogAccepted":true}}}' > /home/node/.claude.json
+
+# Git config: credential helper + sane defaults (identity comes from env vars)
+COPY --chown=node:node --chmod=755 git-credential-op /usr/local/bin/git-credential-op
+RUN git config --global credential.helper /usr/local/bin/git-credential-op && \
+  git config --global commit.gpgSign false && \
+  git config --global tag.gpgSign false && \
+  git config --global core.autocrlf input && \
+  git config --global init.defaultBranch main && \
+  git config --global pull.rebase true && \
+  git config --global push.autoSetupRemote true

--- a/docker/Dockerfile.proxy
+++ b/docker/Dockerfile.proxy
@@ -1,0 +1,11 @@
+FROM debian:12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  tinyproxy \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY tinyproxy.conf /etc/tinyproxy/tinyproxy.conf
+COPY tinyproxy-filter /etc/tinyproxy/filter
+
+EXPOSE 8888
+CMD ["tinyproxy", "-d"]

--- a/docker/agent-run
+++ b/docker/agent-run
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# agent-run: Launch AI coding agents in Docker with isolation.
+# OP_SERVICE_ACCOUNT_TOKEN is the only secret passed from host to container.
+# All other credentials are fetched inside the container from 1Password.
+#
+# Network isolation: a tinyproxy sidecar enforces a domain allowlist for tools
+# that respect HTTP_PROXY/HTTPS_PROXY. Container hardening (--cap-drop=ALL,
+# --security-opt=no-new-privileges) provides the primary security boundary.
+#
+# Usage:
+#   agent-run claude [args...]
+#   agent-run codex [args...]
+
+# Ensure Docker daemon is available before proceeding
+if ! docker ps -q >/dev/null 2>&1; then
+  echo "ERROR: Docker daemon is unreachable. Is it running?" >&2
+  exit 1
+fi
+
+IMAGE_NAME="agent-sandbox"
+PROXY_IMAGE="agent-proxy"
+PROXY_NAME="agent-tinyproxy"
+PROXY_NETWORK="agent-proxy"
+PROXY_PORT="8888"
+
+AGENT="${1:?Usage: agent-run <claude|codex> [args...]}"
+shift
+
+case "$AGENT" in
+  claude|codex) ;;
+  *) echo "Unknown agent: $AGENT (supported: claude, codex)" >&2; exit 1 ;;
+esac
+
+# Container name from git context: <agent>-<repo>-<branch>
+REPO_NAME=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")
+BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "nobranch")
+CONTAINER_NAME=$(echo "${AGENT}-${REPO_NAME}-${BRANCH}" | sed 's/[^a-zA-Z0-9._-]/-/g')
+
+# Host git identity
+GIT_NAME=$(git config user.name || echo "Agent")
+GIT_EMAIL=$(git config user.email || echo "agent@localhost")
+
+# Worktree support: if in a worktree, bind-mount the main .git dir so
+# the container can follow gitdir/commondir references.
+# Mounted rw so the agent can commit and push from within the container.
+WORKTREE_VOLUMES=()
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null || true)
+if [[ -n "$GIT_COMMON_DIR" && "$GIT_COMMON_DIR" != "$(git rev-parse --git-dir 2>/dev/null || true)" ]]; then
+  GIT_COMMON_DIR=$(cd "$GIT_COMMON_DIR" && pwd)
+  WORKTREE_VOLUMES+=(-v "$GIT_COMMON_DIR:$GIT_COMMON_DIR")
+fi
+
+# The one secret: 1Password service account token.
+# Fetched from the Private vault by the human on the host — the agent never has
+# access to Private. The token itself is scoped to the Agents vault only (API
+# keys, Git PATs), so even if the agent exfiltrates it, blast radius is limited
+# to Agents-vault items with no write access to credentials infrastructure.
+: "${OP_SERVICE_ACCOUNT_TOKEN:=$(op item get "Service Account Auth Token: Agents" --vault Private --field credential --reveal)}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Always build — layer cache makes this instant when nothing changed
+docker build -t "$IMAGE_NAME" "$SCRIPT_DIR"
+
+# Ensure the proxy network exists.
+# Note: not --internal so op/claude/etc. work even if they don't honour HTTPS_PROXY.
+# Outbound filtering is enforced by tinyproxy (FilterDefaultDeny) for compliant tools;
+# container hardening (--cap-drop=ALL, --security-opt) provides the primary security boundary.
+docker network create "$PROXY_NETWORK" 2>/dev/null || true
+
+# Ensure the tinyproxy sidecar is running.
+# It is long-lived and shared across agent invocations.
+if [[ "$(docker inspect --format '{{.State.Running}}' "$PROXY_NAME" 2>/dev/null)" != "true" ]]; then
+  docker rm -f "$PROXY_NAME" 2>/dev/null || true
+  docker build -f "$SCRIPT_DIR/Dockerfile.proxy" -t "$PROXY_IMAGE" "$SCRIPT_DIR"
+  # Start on the default bridge (internet access), then also join the internal
+  # proxy network so agent containers can reach it by name.
+  docker run -d \
+    --name "$PROXY_NAME" \
+    --restart=unless-stopped \
+    "$PROXY_IMAGE"
+  docker network connect "$PROXY_NETWORK" "$PROXY_NAME"
+fi
+
+# Remove stale container if present, then ensure cleanup on exit
+docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+trap 'docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true' EXIT
+
+# Create container in detached mode.
+# --cap-drop=ALL: drop all capabilities.
+# --security-opt=no-new-privileges: prevent privilege escalation.
+# HTTP_PROXY / HTTPS_PROXY: route outbound traffic through tinyproxy.
+docker run -d \
+  --name "$CONTAINER_NAME" \
+  --network="$PROXY_NETWORK" \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --memory=8g --cpus=4 --pids-limit=256 \
+  -v "$(pwd):/workspace" \
+  "${WORKTREE_VOLUMES[@]}" \
+  -e HTTP_PROXY="http://${PROXY_NAME}:${PROXY_PORT}" \
+  -e HTTPS_PROXY="http://${PROXY_NAME}:${PROXY_PORT}" \
+  -e NO_PROXY="localhost,127.0.0.1" \
+  -e GIT_AUTHOR_NAME="$GIT_NAME" \
+  -e GIT_AUTHOR_EMAIL="$GIT_EMAIL" \
+  -e GIT_COMMITTER_NAME="$GIT_NAME" \
+  -e GIT_COMMITTER_EMAIL="$GIT_EMAIL" \
+  "$IMAGE_NAME" \
+  sleep infinity >/dev/null
+
+# Detect TTY: attach one only when both stdin and stdout are terminals.
+# Piping or CI contexts get -i only, which keeps stdin available without a PTY.
+TTY_FLAGS=(-i)
+[[ -t 0 && -t 1 ]] && TTY_FLAGS+=(-t)
+
+# Pass OP_SERVICE_ACCOUNT_TOKEN via docker exec -e, not docker run -e, so it
+# does not appear in `docker inspect` container config. The token is in the
+# exec'd process's own environment — the agent uses it directly and already
+# has access to its own /proc/self/environ regardless.
+docker exec "${TTY_FLAGS[@]}" \
+  -e OP_SERVICE_ACCOUNT_TOKEN="$OP_SERVICE_ACCOUNT_TOKEN" \
+  "$CONTAINER_NAME" \
+  bash -c '
+case "$1" in
+  claude)
+    CLAUDE_CODE_OAUTH_TOKEN=$(op item get "Anthropic API Key" --vault Agents --field credential --reveal) || {
+      echo "ERROR: Failed to fetch Anthropic API key from 1Password" >&2
+      exit 1
+    }
+    export CLAUDE_CODE_OAUTH_TOKEN
+    exec claude --dangerously-skip-permissions "${@:2}"
+    ;;
+  codex)
+    OPENAI_API_KEY=$(op item get "OpenAI API Key" --vault Agents --field credential --reveal) || {
+      echo "ERROR: Failed to fetch OpenAI API key from 1Password" >&2
+      exit 1
+    }
+    export OPENAI_API_KEY
+    exec codex "${@:2}"
+    ;;
+esac
+' -- "$AGENT" "$@"

--- a/docker/git-credential-op
+++ b/docker/git-credential-op
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Git credential helper that fetches tokens from 1Password on demand.
+# Requires OP_SERVICE_ACCOUNT_TOKEN in the environment.
+#
+# Git calls this with "get" on stdin, providing host= and protocol= lines.
+# We match the host to a 1Password item and return the token.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+# Only handle "get" operations; silently ignore others
+[ "$1" = "get" ] || exit 0
+
+# Input validation: require OP_SERVICE_ACCOUNT_TOKEN
+if [ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]; then
+  exit 0
+fi
+
+# Parse input, validate host format
+host=""
+while IFS='=' read -r key value; do
+  case "$key" in
+    host)
+      # Validate host format: only alphanumerics, dots, hyphens
+      if echo "$value" | grep -qE '^[a-zA-Z0-9.-]+$'; then
+        host="$value"
+      fi
+      ;;
+  esac
+done
+
+# Reject empty or unvalidated host
+if [ -z "$host" ]; then
+  exit 0
+fi
+
+# Match host to credential item (conservative whitelist)
+case "$host" in
+  github.com|*.github.com)
+    item="GitHub PAT: Agent"
+    username="x-access-token"
+    ;;
+  gitlab.com|*.gitlab.com)
+    item="GitLab Token: Agent"
+    username="oauth2"
+    ;;
+  bitbucket.org|*.bitbucket.org)
+    item="Bitbucket Token: Agent"
+    username="x-token-auth"
+    ;;
+  dev.azure.com|*.visualstudio.com)
+    item="Azure Token: Agent"
+    username="x-access-token"
+    ;;
+  *)
+    # Unknown host - fail safely (no credential)
+    exit 0
+    ;;
+esac
+
+# Fetch token from 1Password (fail gracefully on error)
+token=$(op item get "$item" --vault Agents --field credential --reveal 2>/dev/null) || exit 0
+
+# Output credentials only if token was successfully retrieved
+if [ -n "$token" ]; then
+  printf 'username=%s\npassword=%s\n' "$username" "$token"
+fi

--- a/docker/link.sh
+++ b/docker/link.sh
@@ -1,0 +1,2 @@
+mkdir -p "$HOME/.local/bin"
+ln -sfn "$modpath/agent-run" "$HOME/.local/bin/agent-run"

--- a/docker/tinyproxy-filter
+++ b/docker/tinyproxy-filter
@@ -1,0 +1,20 @@
+# Tinyproxy domain allowlist (POSIX extended regex, matched against hostname)
+# FilterExtended On — these are ERE patterns
+
+# 1Password
+^my\.1password\.com$
+
+# Anthropic
+^api\.anthropic\.com$
+
+# OpenAI
+^api\.openai\.com$
+
+# npm
+^registry\.npmjs\.org$
+
+# GitHub (main site, API, subdomains)
+^(.*\.)?github\.com$
+
+# GitHub content delivery
+^(.*\.)?githubusercontent\.com$

--- a/docker/tinyproxy.conf
+++ b/docker/tinyproxy.conf
@@ -1,0 +1,13 @@
+Port 8888
+Listen 0.0.0.0
+Timeout 600
+LogLevel Warning
+MaxClients 50
+
+# Domain allowlist — FilterDefaultDeny means only matches are allowed
+Filter "/etc/tinyproxy/filter"
+FilterExtended On
+FilterDefaultDeny Yes
+
+# Allow connections from any container on the proxy network
+Allow 0.0.0.0/0


### PR DESCRIPTION
Add Docker setup with Dockerfile, tinyproxy config, and helper scripts for running Claude in an isolated container. Update 1Password vault references from "Claude" to "Agents" in git_ssh.sh and rc.sh.